### PR TITLE
Split GitHub Actions workflows into separate CI and deploy stages

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,4 +1,4 @@
-name: Build and Deploy
+name: Build and Test
 
 on:
   push:
@@ -10,13 +10,16 @@ on:
       - 'Cargo**'
       - 'src/**/*.rs'
 
+  pull_request:
+    branches:
+      - main
+
 jobs:
-  build-and-package:
+  ci:
     runs-on: ubuntu-24.04-arm
 
     env:
       BUILD_TARGET: aarch64-unknown-linux-musl
-      PROJECT: log-stream-gc
 
     steps:
       - uses: actions/checkout@v4
@@ -44,34 +47,16 @@ jobs:
         run: cargo clippy --target ${{ env.BUILD_TARGET }} -- -D warnings
 
       - name: Package
+        if: github.event_name == 'push'
         run: |
           cargo build --release --target ${{ env.BUILD_TARGET }}
           cp target/${{ env.BUILD_TARGET }}/release/lambda bootstrap
           zip -j ${{ env.PROJECT }}.zip bootstrap
 
       - name: Upload Package
+        if: github.event_name == 'push'
         uses: actions/upload-artifact@v4
         with:
           name: package
           path: ${{ env.PROJECT }}.zip
           retention-days: 1
-
-  deploy-us-east-1:
-    needs: build-and-package
-
-    uses: ./.github/workflows/deploy-lambda.yml
-    with:
-      aws-region: us-east-1
-    secrets:
-      aws-account-id: ${{ secrets.AWS_ACCOUNT_ID }}
-      bucket-name: ${{ secrets.AWS_US_EAST_1_BUCKET }}
-
-  deploy-us-east-2:
-    needs: build-and-package
-
-    uses: ./.github/workflows/deploy-lambda.yml
-    with:
-      aws-region: us-east-2
-    secrets:
-      aws-account-id: ${{ secrets.AWS_ACCOUNT_ID }}
-      bucket-name: ${{ secrets.AWS_US_EAST_2_BUCKET }}

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -20,6 +20,7 @@ jobs:
 
     env:
       BUILD_TARGET: aarch64-unknown-linux-musl
+      PROJECT: log-stream-gc
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -15,7 +15,7 @@ on:
       - main
 
 jobs:
-  ci:
+  build-and-test:
     runs-on: ubuntu-24.04-arm
 
     env:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,30 @@
+name: Deploy
+
+on:
+  workflow_run:
+    workflows: ["Build and Test"]
+
+    types:
+      - completed
+
+    branches:
+      - main
+
+jobs:
+  deploy-us-east-1:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    uses: ./.github/workflows/deploy-lambda.yml
+    with:
+      aws-region: us-east-1
+    secrets:
+      aws-account-id: ${{ secrets.AWS_ACCOUNT_ID }}
+      bucket-name: ${{ secrets.AWS_US_EAST_1_BUCKET }}
+
+  deploy-us-east-2:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    uses: ./.github/workflows/deploy-lambda.yml
+    with:
+      aws-region: us-east-2
+    secrets:
+      aws-account-id: ${{ secrets.AWS_ACCOUNT_ID }}
+      bucket-name: ${{ secrets.AWS_US_EAST_2_BUCKET }}


### PR DESCRIPTION
- Replace single build-and-deploy workflow with build-and-test workflow for CI
- Add separate deploy workflow that triggers after build-and-test completes
- CI workflow runs on both PRs and main pushes
- Deploy workflow only runs on main pushes after CI passes

🤖 Generated with [Claude Code](https://claude.ai/code)