### PR TITLE
Refactor for cleanliness: SDK retries, global concurrency, lint tests

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -45,7 +45,7 @@ jobs:
         run: cargo test --target ${{ env.BUILD_TARGET }}
 
       - name: Lint
-        run: cargo clippy --target ${{ env.BUILD_TARGET }} -- -D warnings
+        run: cargo clippy --target ${{ env.BUILD_TARGET }} --all-targets -- -D warnings
 
       - name: Package
         if: github.event_name == 'push'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,10 +17,10 @@ The project has a dual-binary structure:
 
 The core algorithm:
 
-1. Enumerates all CloudWatch log groups in a region
-2. For each log group, calculates a cutoff date (2× the retention period)
-3. Deletes log streams created before the cutoff date
-4. Uses AWS SDK with retry configuration (25 max attempts) to handle throttling
+1. Enumerates all CloudWatch log groups in a region (optionally filtered by include/exclude regex)
+2. For each log group, calculates a cutoff date (retention period × a configurable multiplier, default 2×)
+3. Deletes log streams created before the cutoff date, with a global concurrency limit on deletions
+4. Uses the AWS SDK's standard retry configuration (10 max attempts) to handle throttling
 
 ## Development Commands
 
@@ -30,7 +30,7 @@ The core algorithm:
 - `cargo fmt` - Format the source code
 - `cargo test` - Run all tests
 - `cargo check` - Check for compilation errors without building
-- `cargo clippy -- -D warnings` - Run Rust linter for code quality checks
+- `cargo clippy --all-targets -- -D warnings` - Run Rust linter for code quality checks (includes test code)
 
 ## Dependencies
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1406,7 +1406,7 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 [[package]]
 name = "jluszcz_rust_utils"
 version = "0.1.0"
-source = "git+https://github.com//jluszcz/rust-utils#eaa5adecedf3b57d1cd97e52a65ca8935046ff55"
+source = "git+https://github.com/jluszcz/rust-utils#eaa5adecedf3b57d1cd97e52a65ca8935046ff55"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,15 +9,15 @@ edition = "2024"
 anyhow = "1"
 aws-config = { version = "1", features = ["behavior-version-latest"] }
 aws-sdk-cloudwatchlogs = { version = "1", features = ["behavior-version-latest"] }
-chrono = { version = "0", features = ["serde"] }
+chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "4", features = ["env"] }
-futures = "0"
-jluszcz_rust_utils = { git = "https://github.com//jluszcz/rust-utils" }
+futures = "0.3"
+jluszcz_rust_utils = { git = "https://github.com/jluszcz/rust-utils" }
 lambda_runtime = "1"
-log = "0"
+log = "0.4"
 regex = "1"
 serde_json = "1"
-tokio = { version = "1", features = ["macros", "rt-multi-thread", "time"] }
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "sync"] }
 
 [[bin]]
 name = "main"

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Log groups without a retention policy are skipped.
 1. Enumerate all CloudWatch log groups in the target region (optionally filtered by regex)
 2. For each log group, compute a cutoff date: `now - (retention_period × retention_multiplier)`
 3. Delete all log streams whose creation time is before the cutoff date
-4. Throttling errors on deletion are retried with exponential backoff (up to 5 attempts)
+4. Throttling and transient errors are retried via the AWS SDK's standard exponential backoff (up to 10 attempts)
 
 ## Usage
 
@@ -31,7 +31,7 @@ log-stream-gc [OPTIONS] --region <REGION>
 |---|---|---|---|
 | `--region <REGION>` | `-r` | *(required)* | AWS region to run garbage collection in. Also reads `AWS_REGION`. |
 | `--dryrun` | `-d` | `false` | Log what would be deleted without actually deleting anything. |
-| `--concurrency <NUM>` | `-c` | `10` | Number of concurrent log stream deletions per log group. |
+| `--concurrency <NUM>` | `-c` | `10` | Maximum number of concurrent log stream deletions across all log groups. |
 | `--retention-multiplier <NUM>` | | `2.0` | Multiplier applied to the log group's retention period to determine the cutoff. |
 | `--batch-size <NUM>` | | `50` | Number of log groups to process per batch. |
 | `--include-pattern <REGEX>` | | | Only process log groups whose name matches this regex. |
@@ -76,8 +76,7 @@ The Lambda execution role requires:
 ```json
 {
   "logs:Describe*": "arn:aws:logs:<region>:<account>:*",
-  "logs:DeleteLogStream": "arn:aws:logs:<region>:<account>:*",
-  "cloudwatch:PutMetricData": "*" (scoped to namespace "log_stream_gc")
+  "logs:DeleteLogStream": "arn:aws:logs:<region>:<account>:*"
 }
 ```
 
@@ -88,7 +87,7 @@ Plus `AWSLambdaBasicExecutionRole` for CloudWatch Logs write access.
 Pushes to `main` that touch `src/**`, `Cargo*`, or `.github/workflows/**` trigger the CI/CD pipeline:
 
 1. **Build & test** on `ubuntu-24.04-arm` targeting `aarch64-unknown-linux-musl`
-2. **Lint** with `cargo clippy -- -D warnings`
+2. **Lint** with `cargo clippy --all-targets -- -D warnings`
 3. **Package** the `lambda` binary as `log-stream-gc.zip`
 4. **Deploy** to `us-east-1` and `us-east-2` in parallel via `deploy-lambda.yml`
 
@@ -102,5 +101,5 @@ cargo build       # Build
 cargo test        # Run tests
 cargo fmt         # Format
 cargo check       # Check without building
-cargo clippy -- -D warnings  # Lint
+cargo clippy --all-targets -- -D warnings  # Lint (including tests)
 ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,18 +6,25 @@ use aws_sdk_cloudwatchlogs::config::Region;
 use aws_sdk_cloudwatchlogs::types::{LogGroup, LogStream};
 use chrono::{DateTime, Duration, NaiveDate, Utc};
 use futures::stream::{self, StreamExt};
-use log::{debug, info, trace, warn};
+use log::{debug, info, warn};
 use regex::Regex;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Instant;
-use tokio::task;
-use tokio::time::{Duration as TokioDuration, sleep};
+use tokio::sync::Semaphore;
 
 pub const APP_NAME: &str = "log_stream_gc";
 
+/// Throttling and transient errors are handled by the SDK's standard retry
+/// (exponential backoff with jitter) rather than a hand-rolled retry loop.
+const RETRY_MAX_ATTEMPTS: u32 = 10;
+
 #[derive(Debug, Clone)]
 pub struct Config {
+    /// Bounds three kinds of parallelism in a run: the global cap on in-flight
+    /// log stream deletions (the binding constraint, enforced by a semaphore),
+    /// the number of streams examined concurrently within each log group, and
+    /// the number of log group batches processed concurrently.
     pub concurrency_limit: usize,
     pub progress_threshold: usize,
     pub progress_interval: usize,
@@ -28,6 +35,7 @@ pub struct Config {
 }
 
 impl Default for Config {
+    // These defaults must match the clap default_value strings in main.rs.
     fn default() -> Self {
         Self {
             concurrency_limit: 10,
@@ -41,15 +49,26 @@ impl Default for Config {
     }
 }
 
+/// State shared by every task in a single garbage collection run.
+struct GcContext {
+    client: Client,
+    config: Config,
+    dry_run: bool,
+    /// Caps in-flight log stream deletions across all log groups.
+    delete_semaphore: Semaphore,
+    processed_streams: AtomicUsize,
+    total_streams: AtomicUsize,
+    processed_groups: AtomicUsize,
+    failed_groups: AtomicUsize,
+    start_time: Instant,
+}
+
 fn parse_timestamp(timestamp: i64) -> Result<DateTime<Utc>> {
     if timestamp < 0 {
         return Err(anyhow!("Invalid timestamp: {}", timestamp));
     }
 
-    let secs = timestamp / 1000;
-    let nsecs = ((timestamp % 1000) * 1_000_000) as u32;
-
-    DateTime::<Utc>::from_timestamp(secs, nsecs)
+    DateTime::from_timestamp_millis(timestamp)
         .ok_or_else(|| anyhow!("Failed to parse timestamp: {}", timestamp))
 }
 
@@ -79,42 +98,33 @@ fn should_process_log_group(group: &LogGroup, config: &Config) -> bool {
 }
 
 async fn describe_log_streams(client: &Client, log_group_name: &str) -> Result<Vec<LogStream>> {
-    let mut next_token = None;
     let mut log_streams = Vec::new();
 
-    loop {
-        trace!("Describing log streams for {log_group_name} (next_token={next_token:?})");
+    let mut pages = client
+        .describe_log_streams()
+        .log_group_name(log_group_name)
+        .into_paginator()
+        .send();
 
-        let describe_output = client
-            .describe_log_streams()
-            .log_group_name(log_group_name)
-            .set_next_token(next_token)
-            .send()
-            .await
-            .with_context(|| {
-                format!("Failed to describe log streams for log group: {log_group_name}")
-            })?;
-        debug!("Described log streams for {log_group_name}");
-
-        log_streams.extend(describe_output.log_streams.unwrap_or_default());
-
-        next_token = describe_output.next_token;
-        if next_token.is_none() {
-            info!(
-                "Found {} log stream(s) for {log_group_name}",
-                log_streams.len()
-            );
-            break Ok(log_streams);
-        }
+    while let Some(page) = pages.next().await {
+        let page = page.with_context(|| {
+            format!("Failed to describe log streams for log group: {log_group_name}")
+        })?;
+        log_streams.extend(page.log_streams.unwrap_or_default());
     }
+
+    info!(
+        "Found {} log stream(s) for {log_group_name}",
+        log_streams.len()
+    );
+    Ok(log_streams)
 }
 
 async fn gc_log_stream(
-    client: &Client,
+    ctx: &GcContext,
     keep_from_date: &NaiveDate,
     log_group_name: &str,
     log_stream: LogStream,
-    dry_run: bool,
 ) -> Result<()> {
     let log_stream_name = log_stream
         .log_stream_name()
@@ -133,19 +143,25 @@ async fn gc_log_stream(
     if log_stream_creation_date < *keep_from_date {
         debug!(
             "{} {log_group_name}/{log_stream_name} (creation date {log_stream_creation_date} < {keep_from_date})",
-            if dry_run {
+            if ctx.dry_run {
                 "Keeping (Dry-Run)"
             } else {
                 "Deleting"
             }
         );
 
-        if !dry_run {
-            delete_log_stream_with_retry(client, log_group_name, log_stream_name)
+        if !ctx.dry_run {
+            let _permit = ctx.delete_semaphore.acquire().await?;
+            ctx.client
+                .delete_log_stream()
+                .log_group_name(log_group_name)
+                .log_stream_name(log_stream_name)
+                .send()
                 .await
                 .with_context(|| {
                     format!("Failed to delete log stream: {log_group_name}/{log_stream_name}")
                 })?;
+            debug!("Deleted {log_group_name}/{log_stream_name}");
         }
     } else {
         debug!(
@@ -156,57 +172,7 @@ async fn gc_log_stream(
     Ok(())
 }
 
-async fn delete_log_stream_with_retry(
-    client: &Client,
-    log_group_name: &str,
-    log_stream_name: &str,
-) -> Result<()> {
-    const MAX_RETRIES: u32 = 5;
-    const BASE_DELAY_MS: u64 = 100;
-
-    let mut attempt: u32 = 0;
-    loop {
-        match client
-            .delete_log_stream()
-            .log_group_name(log_group_name)
-            .log_stream_name(log_stream_name)
-            .send()
-            .await
-        {
-            Ok(_) => {
-                debug!("Deleted {log_group_name}/{log_stream_name}");
-                return Ok(());
-            }
-            Err(err) => {
-                let error_message = err.to_string().to_lowercase();
-                let is_throttle =
-                    error_message.contains("throttl") || error_message.contains("rate");
-
-                if !is_throttle || attempt >= MAX_RETRIES {
-                    return Err(anyhow::Error::from(err));
-                }
-
-                let delay_ms = BASE_DELAY_MS * 2_u64.pow(attempt);
-                warn!(
-                    "Throttling detected for {log_group_name}/{log_stream_name}, retrying in {delay_ms}ms (attempt {}/{})",
-                    attempt + 1,
-                    MAX_RETRIES + 1
-                );
-                sleep(TokioDuration::from_millis(delay_ms)).await;
-                attempt += 1;
-            }
-        }
-    }
-}
-
-async fn gc_log_group(
-    client: &Client,
-    log_group: LogGroup,
-    config: &Config,
-    dry_run: bool,
-    processed_counter: Arc<AtomicUsize>,
-    total_streams: Arc<AtomicUsize>,
-) -> Result<()> {
+async fn gc_log_group(ctx: Arc<GcContext>, log_group: LogGroup) -> Result<()> {
     let log_group_name = log_group
         .log_group_name()
         .ok_or_else(|| anyhow!("Log group is missing a name"))?
@@ -218,136 +184,126 @@ async fn gc_log_group(
         .expect("log group passed should_process_log_group filter")
         .into();
 
-    let retention_days = (log_group_retention_period as f64 * config.retention_multiplier) as i64;
+    let retention_days =
+        (log_group_retention_period as f64 * ctx.config.retention_multiplier) as i64;
     let keep_from_date = Utc::now().date_naive()
         - Duration::try_days(retention_days)
             .ok_or_else(|| anyhow!("Failed to create duration for {} days", retention_days))?;
 
     debug!(
         "Cleaning up {log_group_name} from before {keep_from_date} (retention: {}d * {} = {}d)",
-        log_group_retention_period, config.retention_multiplier, retention_days
+        log_group_retention_period, ctx.config.retention_multiplier, retention_days
     );
 
-    let log_streams = describe_log_streams(client, &log_group_name).await?;
+    let log_streams = describe_log_streams(&ctx.client, &log_group_name).await?;
     let log_stream_ct = log_streams.len();
-    total_streams.fetch_add(log_stream_ct, Ordering::Relaxed);
+    ctx.total_streams
+        .fetch_add(log_stream_ct, Ordering::Relaxed);
 
     if log_stream_ct == 0 {
         debug!("No log streams found in {log_group_name}");
         return Ok(());
     }
 
-    let progress_threshold = config.progress_threshold;
-    let progress_interval = config.progress_interval;
-    let concurrency_limit = config.concurrency_limit;
-
-    let start_time = Instant::now();
+    let group_start = Instant::now();
     let stream_futures = stream::iter(log_streams.into_iter().enumerate())
         .map(|(idx, log_stream)| {
-            let client = client.clone();
+            let ctx = Arc::clone(&ctx);
             let log_group_name = log_group_name.clone();
-            let processed_counter = processed_counter.clone();
 
             async move {
-                let result = gc_log_stream(
-                    &client,
-                    &keep_from_date,
-                    &log_group_name,
-                    log_stream,
-                    dry_run,
-                )
-                .await;
+                let result =
+                    gc_log_stream(&ctx, &keep_from_date, &log_group_name, log_stream).await;
 
-                let processed = processed_counter.fetch_add(1, Ordering::Relaxed) + 1;
+                let processed = ctx.processed_streams.fetch_add(1, Ordering::Relaxed) + 1;
 
-                if log_stream_ct > progress_threshold && (idx + 1) % progress_interval == 0 {
-                    let elapsed = start_time.elapsed();
-                    let rate = processed as f64 / elapsed.as_secs_f64();
+                if log_stream_ct > ctx.config.progress_threshold
+                    && (idx + 1) % ctx.config.progress_interval == 0
+                {
+                    let rate = processed as f64 / ctx.start_time.elapsed().as_secs_f64();
                     info!(
-                        "Processed {}/{log_stream_ct} log streams in {log_group_name} ({:.1} streams/sec)",
-                        idx + 1,
-                        rate
+                        "Processed {}/{log_stream_ct} log streams in {log_group_name} ({rate:.1} streams/sec overall)",
+                        idx + 1
                     );
                 }
 
                 result
             }
         })
-        .buffer_unordered(concurrency_limit);
+        .buffer_unordered(ctx.config.concurrency_limit);
 
-    let results: Vec<Result<()>> = stream_futures.collect().await;
+    let errors: Vec<_> = stream_futures
+        .collect::<Vec<_>>()
+        .await
+        .into_iter()
+        .filter_map(Result::err)
+        .collect();
 
-    let mut errors = Vec::new();
-    for result in results {
-        if let Err(e) = result {
-            errors.push(e);
-        }
-    }
-
-    if !errors.is_empty() {
-        let error_count = errors.len();
-        let first_error = errors.into_iter().next().unwrap();
+    let error_count = errors.len();
+    if let Some(first_error) = errors.into_iter().next() {
         return Err(anyhow!(
-            "Failed to process {} log streams in {}: {}",
-            error_count,
-            log_group_name,
-            first_error
+            "Failed to process {error_count} log streams in {log_group_name}: {first_error}"
         ));
     }
 
-    let elapsed = start_time.elapsed();
     debug!(
-        "Completed processing {} log streams in {} in {:.2}s",
-        log_stream_ct,
-        log_group_name,
-        elapsed.as_secs_f64()
+        "Completed processing {log_stream_ct} log streams in {log_group_name} in {:.2}s",
+        group_start.elapsed().as_secs_f64()
     );
 
     Ok(())
 }
 
-pub async fn gc_log_streams(region: Option<String>, config: Config, dry_run: bool) -> Result<()> {
+pub async fn gc_log_streams(
+    region: Option<String>,
+    mut config: Config,
+    dry_run: bool,
+) -> Result<()> {
     let mut aws_config = ConfigLoader::default();
     if let Some(region) = region {
         aws_config = aws_config.region(Region::new(region));
     }
 
     let aws_config = aws_config
-        .retry_config(RetryConfig::standard())
+        .retry_config(RetryConfig::standard().with_max_attempts(RETRY_MAX_ATTEMPTS))
         .load()
         .await;
 
-    let client = Client::new(&aws_config);
-    let config = Arc::new(config);
-
-    let processed_counter = Arc::new(AtomicUsize::new(0));
-    let total_streams = Arc::new(AtomicUsize::new(0));
-    let processed_groups = Arc::new(AtomicUsize::new(0));
-    let start_time = Instant::now();
-    let mut batch_handles = Vec::new();
-    let max_concurrent_batches = config.concurrency_limit.max(1);
+    // Clamp once so every use of the limit (semaphore, buffer_unordered, batch cap) agrees.
+    config.concurrency_limit = config.concurrency_limit.max(1);
+    let concurrency_limit = config.concurrency_limit;
     let page_limit = config.batch_size.clamp(1, 50) as i32;
 
-    let mut next_token: Option<String> = None;
+    let ctx = Arc::new(GcContext {
+        client: Client::new(&aws_config),
+        dry_run,
+        delete_semaphore: Semaphore::new(concurrency_limit),
+        processed_streams: AtomicUsize::new(0),
+        total_streams: AtomicUsize::new(0),
+        processed_groups: AtomicUsize::new(0),
+        failed_groups: AtomicUsize::new(0),
+        start_time: Instant::now(),
+        config,
+    });
+
+    let mut batch_handles = Vec::new();
     let mut total_log_groups: usize = 0;
     let mut page_count: usize = 0;
 
-    loop {
-        trace!("Describing log groups (next_token={next_token:?})");
+    let mut pages = ctx
+        .client
+        .describe_log_groups()
+        .limit(page_limit)
+        .into_paginator()
+        .send();
 
-        let output = client
-            .describe_log_groups()
-            .limit(page_limit)
-            .set_next_token(next_token)
-            .send()
-            .await
-            .context("Failed to describe log groups")?;
-
+    while let Some(page) = pages.next().await {
+        let output = page.context("Failed to describe log groups")?;
         page_count += 1;
 
         let mut batch = output.log_groups.unwrap_or_default();
         let before_filter = batch.len();
-        batch.retain(|g| should_process_log_group(g, &config));
+        batch.retain(|g| should_process_log_group(g, &ctx.config));
         let filtered_out = before_filter - batch.len();
 
         debug!(
@@ -355,64 +311,42 @@ pub async fn gc_log_streams(region: Option<String>, config: Config, dry_run: boo
             batch.len()
         );
 
-        if !batch.is_empty() {
-            total_log_groups += batch.len();
+        if batch.is_empty() {
+            continue;
+        }
+        total_log_groups += batch.len();
 
-            let handle = tokio::spawn({
-                let client = client.clone();
-                let config = Arc::clone(&config);
-                let processed_counter = processed_counter.clone();
-                let total_streams = total_streams.clone();
-                let processed_groups = processed_groups.clone();
+        let handle = tokio::spawn({
+            let ctx = Arc::clone(&ctx);
 
-                async move {
-                    for log_group in batch {
-                        let log_group_name =
-                            log_group.log_group_name().unwrap_or("unknown").to_string();
-                        let group_num = processed_groups.fetch_add(1, Ordering::Relaxed) + 1;
+            async move {
+                for log_group in batch {
+                    let log_group_name =
+                        log_group.log_group_name().unwrap_or("unknown").to_string();
+                    let group_num = ctx.processed_groups.fetch_add(1, Ordering::Relaxed) + 1;
 
-                        debug!("Processing log group {log_group_name} (group #{group_num})");
+                    debug!("Processing log group {log_group_name} (group #{group_num})");
 
-                        if let Err(e) = gc_log_group(
-                            &client,
-                            log_group,
-                            &config,
-                            dry_run,
-                            processed_counter.clone(),
-                            total_streams.clone(),
-                        )
-                        .await
-                        {
-                            warn!("Failed to process log group {log_group_name}: {e}");
-                        }
-
-                        task::yield_now().await;
+                    if let Err(e) = gc_log_group(Arc::clone(&ctx), log_group).await {
+                        ctx.failed_groups.fetch_add(1, Ordering::Relaxed);
+                        warn!("Failed to process log group {log_group_name}: {e}");
                     }
                 }
-            });
-            batch_handles.push(handle);
-
-            if batch_handles.len() >= max_concurrent_batches {
-                let (completed, _, remaining) = futures::future::select_all(batch_handles).await;
-                if let Err(e) = completed {
-                    warn!("Batch processing task failed: {e}");
-                }
-                batch_handles = remaining;
             }
-        }
+        });
+        batch_handles.push(handle);
 
-        next_token = output.next_token;
-        if next_token.is_none() {
-            break;
+        if batch_handles.len() >= concurrency_limit {
+            let (completed, _, remaining) = futures::future::select_all(batch_handles).await;
+            if let Err(e) = completed {
+                ctx.failed_groups.fetch_add(1, Ordering::Relaxed);
+                warn!("Batch processing task failed: {e}");
+            }
+            batch_handles = remaining;
         }
     }
 
     info!("Found {total_log_groups} log group(s) after filtering");
-
-    if total_log_groups == 0 {
-        info!("No log groups found matching the specified criteria");
-        return Ok(());
-    }
 
     debug!(
         "Waiting for {} batch processing tasks to complete",
@@ -421,13 +355,14 @@ pub async fn gc_log_streams(region: Option<String>, config: Config, dry_run: boo
 
     for handle in batch_handles {
         if let Err(e) = handle.await {
+            ctx.failed_groups.fetch_add(1, Ordering::Relaxed);
             warn!("Batch processing task failed: {e}");
         }
     }
 
-    let total_processed = processed_counter.load(Ordering::Relaxed);
-    let total_stream_count = total_streams.load(Ordering::Relaxed);
-    let elapsed = start_time.elapsed();
+    let total_processed = ctx.processed_streams.load(Ordering::Relaxed);
+    let total_stream_count = ctx.total_streams.load(Ordering::Relaxed);
+    let elapsed = ctx.start_time.elapsed();
 
     info!(
         "Garbage collection completed: processed {}/{} log streams across {} log groups in {:.2}s ({:.1} streams/sec)",
@@ -441,6 +376,13 @@ pub async fn gc_log_streams(region: Option<String>, config: Config, dry_run: boo
             0.0
         }
     );
+
+    let failed_groups = ctx.failed_groups.load(Ordering::Relaxed);
+    if failed_groups > 0 {
+        return Err(anyhow!(
+            "Failed to process {failed_groups} log group(s); see warnings above"
+        ));
+    }
 
     Ok(())
 }
@@ -510,11 +452,16 @@ mod tests {
     fn filter_applies_include_pattern() {
         let group = make_log_group("/aws/lambda/foo", Some(7));
 
-        let mut config = Config::default();
-        config.include_pattern = Some(Regex::new(r"^/aws/lambda/").unwrap());
+        let config = Config {
+            include_pattern: Some(Regex::new(r"^/aws/lambda/").unwrap()),
+            ..Config::default()
+        };
         assert!(should_process_log_group(&group, &config));
 
-        config.include_pattern = Some(Regex::new(r"^/aws/ecs/").unwrap());
+        let config = Config {
+            include_pattern: Some(Regex::new(r"^/aws/ecs/").unwrap()),
+            ..Config::default()
+        };
         assert!(!should_process_log_group(&group, &config));
     }
 
@@ -522,8 +469,10 @@ mod tests {
     fn filter_applies_exclude_pattern() {
         let group = make_log_group("/aws/lambda/foo", Some(7));
 
-        let mut config = Config::default();
-        config.exclude_pattern = Some(Regex::new(r"^/aws/lambda/").unwrap());
+        let config = Config {
+            exclude_pattern: Some(Regex::new(r"^/aws/lambda/").unwrap()),
+            ..Config::default()
+        };
         assert!(!should_process_log_group(&group, &config));
     }
 
@@ -531,9 +480,11 @@ mod tests {
     fn filter_exclude_overrides_include() {
         let group = make_log_group("/aws/lambda/foo", Some(7));
 
-        let mut config = Config::default();
-        config.include_pattern = Some(Regex::new(r"^/aws/").unwrap());
-        config.exclude_pattern = Some(Regex::new(r"foo$").unwrap());
+        let config = Config {
+            include_pattern: Some(Regex::new(r"^/aws/").unwrap()),
+            exclude_pattern: Some(Regex::new(r"foo$").unwrap()),
+            ..Config::default()
+        };
         assert!(!should_process_log_group(&group, &config));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,8 +32,9 @@ fn parse_regex(s: &str) -> Result<Regex, String> {
 }
 
 fn parse_args() -> Result<(Verbosity, bool, String, Config)> {
+    // The default_value strings below must match Config::default() in lib.rs.
     let matches = Command::new("log-stream-gc")
-        .version("0.1")
+        .version(env!("CARGO_PKG_VERSION"))
         .author("Jacob Luszcz")
         .arg(
             Arg::new("verbosity")
@@ -64,7 +65,7 @@ fn parse_args() -> Result<(Verbosity, bool, String, Config)> {
                 .value_name("NUM")
                 .default_value("10")
                 .value_parser(parse_non_zero_usize)
-                .help("Number of concurrent log stream deletions."),
+                .help("Maximum number of concurrent log stream deletions across all log groups."),
         )
         .arg(
             Arg::new("progress-threshold")


### PR DESCRIPTION
- Replace hand-rolled throttle retry (string-matched errors) with the SDK's standard retry config (10 max attempts)
- Cap in-flight log stream deletions across all log groups with a semaphore, instead of per-group concurrency that could reach limit^2
- Compute progress rate from run-wide counters and start time
- Use SDK paginators for describe calls and chrono's from_timestamp_millis
- Bundle shared run state into a GcContext struct
- Fix clippy field_reassign_with_default in tests; lint with --all-targets in CI so test code is covered
- Pin minor versions for chrono/futures/log; read CLI version from Cargo.toml
- Update README and CLAUDE.md: retry behavior, concurrency semantics, stale PutMetricData IAM entry, clippy command