### PR TITLE
chore: rename CI workflow to ci.yml and normalize build job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Build and Deploy
+name: CI
 
 on:
   push:
@@ -15,7 +15,8 @@ on:
       - main
 
 jobs:
-  build-and-package:
+  build:
+    name: Build, Test & Lint
     runs-on: ubuntu-24.04-arm
 
     env:
@@ -63,7 +64,7 @@ jobs:
           retention-days: 1
 
   deploy-us-east-1:
-    needs: build-and-package
+    needs: build
 
     if: github.event_name == 'push'
     uses: ./.github/workflows/deploy-lambda.yml
@@ -73,7 +74,7 @@ jobs:
       aws-account-id: ${{ secrets.AWS_ACCOUNT_ID }}
 
   deploy-us-east-2:
-    needs: build-and-package
+    needs: build
 
     if: github.event_name == 'push'
     uses: ./.github/workflows/deploy-lambda.yml

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Delete CloudWatch log streams after their current retention period has passed.
 
-[![Status Badge](https://github.com/jluszcz/LogStreamGC/actions/workflows/build-and-deploy.yml/badge.svg)](https://github.com/jluszcz/LogStreamGC/actions/workflows/build-and-deploy.yml)
+[![Status Badge](https://github.com/jluszcz/LogStreamGC/actions/workflows/ci.yml/badge.svg)](https://github.com/jluszcz/LogStreamGC/actions/workflows/ci.yml)
 
 ## Overview
 


### PR DESCRIPTION
Rename build-and-deploy.yml to ci.yml and rename the build-and-package job to build (with an explicit "Build, Test & Lint" name) so the check name is consistent across repos.