### PR TITLE
chore(cli): infer long args and lint test code in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
           sudo apt-get install -y musl-tools
           rustup target add ${{ env.BUILD_TARGET }}
           rustup update
-          rustup component add clippy
+          rustup component add clippy rustfmt
 
       - name: Dump Toolchain Info
         run: |
@@ -44,6 +44,9 @@ jobs:
 
       - name: Test
         run: cargo test --target ${{ env.BUILD_TARGET }}
+
+      - name: Format
+        run: cargo fmt --check
 
       - name: Lint
         run: cargo clippy --target ${{ env.BUILD_TARGET }} --all-targets -- -D warnings

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,6 +36,7 @@ fn parse_args() -> Result<(Verbosity, bool, String, Config)> {
     let matches = Command::new("log-stream-gc")
         .version(env!("CARGO_PKG_VERSION"))
         .author("Jacob Luszcz")
+        .infer_long_args(true)
         .arg(
             Arg::new("verbosity")
                 .short('v')


### PR DESCRIPTION
Add infer_long_args to the clap Command so unambiguous long-flag prefixes work, and add a Format (cargo fmt --check) CI step before Lint.