### PR TITLE
ci: add cargo cache and default-deny permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build, Test & Lint
@@ -38,6 +41,9 @@ jobs:
           cargo --version --verbose
           rustc --version
           cargo clippy --version
+
+      - name: Cache Cargo
+        uses: Swatinem/rust-cache@v2
 
       - name: Build
         run: cargo build --target ${{ env.BUILD_TARGET }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,11 @@ jobs:
     needs: build
 
     if: github.event_name == 'push'
+
+    permissions:
+      id-token: write
+      contents: read
+
     uses: ./.github/workflows/deploy-lambda.yml
     with:
       aws-region: us-east-1
@@ -86,6 +91,11 @@ jobs:
     needs: build
 
     if: github.event_name == 'push'
+
+    permissions:
+      id-token: write
+      contents: read
+
     uses: ./.github/workflows/deploy-lambda.yml
     with:
       aws-region: us-east-2


### PR DESCRIPTION
Two CI hardening changes:

- Add a top-level `permissions: contents: read` default-deny block (jobs that need more, e.g. deploy, keep their own job-level permissions).
- Add a `Swatinem/rust-cache@v2` step so cargo build/target artifacts are cached between runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)