### PR TITLE
Fix stale env-script names in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,10 +42,11 @@ The core algorithm:
 
 ## Environment Configuration
 
-The project includes environment files:
+Terraform uses per-region workspaces. Source the matching env script (`. env-<region>`)
+to export `TF_VAR_aws_region` and select the workspace before running `terraform`:
 
-- `env-cmh`: Environment configuration (likely for Columbus)
-- `env-iad`: Environment configuration (likely for Northern Virginia)
+- `env-us_east_1` — region `us-east-1`, workspace `log-stream-gc_us-east-1`
+- `env-us_east_2` — region `us-east-2`, workspace `log-stream-gc_us-east-2`
 
 ## Deployment
 


### PR DESCRIPTION
The **Environment Configuration** section listed `env-cmh`/`env-iad`, which don't exist in the repo. The actual per-region Terraform workspace scripts are `env-us_east_1` and `env-us_east_2` (they `export TF_VAR_aws_region` and `terraform workspace select log-stream-gc_<region>`). Corrected to match reality.

🤖 Generated with [Claude Code](https://claude.com/claude-code)